### PR TITLE
Don't override Close. Use Dispose.

### DIFF
--- a/zlib.managed/ZInputStream.cs
+++ b/zlib.managed/ZInputStream.cs
@@ -19,6 +19,7 @@ namespace Elskom.Generic.Libs
     {
         private byte[] pBuf;
         private byte[] pBuf1 = new byte[1];
+        private bool isDisposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ZInputStream"/> class.
@@ -243,27 +244,6 @@ namespace Elskom.Generic.Libs
         }
 
         /// <inheritdoc/>
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This method should not throw any exceptions.")]
-        public override void Close()
-        {
-            try
-            {
-                try
-                {
-                    this.Finish();
-                }
-                catch (Exception)
-                {
-                }
-            }
-            finally
-            {
-                this.EndStream();
-                this.BaseStream.Close();
-            }
-        }
-
-        /// <inheritdoc/>
         public override void Flush() => this.BaseStream.Flush();
 
         /// <inheritdoc/>
@@ -274,6 +254,34 @@ namespace Elskom.Generic.Libs
 
         /// <inheritdoc/>
         public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (!this.isDisposed)
+            {
+                if (disposing)
+                {
+                    try
+                    {
+                        try
+                        {
+                            this.Finish();
+                        }
+                        catch
+                        {
+                        }
+                    }
+                    finally
+                    {
+                        this.EndStream();
+                    }
+                }
+
+                this.isDisposed = true;
+                base.Dispose(disposing);
+            }
+        }
 
         private void InitBlock()
         {

--- a/zlib.managed/ZOutputStream.cs
+++ b/zlib.managed/ZOutputStream.cs
@@ -19,6 +19,7 @@ namespace Elskom.Generic.Libs
     {
         private byte[] pBuf;
         private byte[] pBuf1 = new byte[1];
+        private bool isDisposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ZOutputStream"/> class.
@@ -239,27 +240,6 @@ namespace Elskom.Generic.Libs
         }
 
         /// <inheritdoc/>
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This method should not throw any exceptions.")]
-        public override void Close()
-        {
-            try
-            {
-                try
-                {
-                    this.Finish();
-                }
-                catch (Exception)
-                {
-                }
-            }
-            finally
-            {
-                this.EndStream();
-                this.BaseStream.Close();
-            }
-        }
-
-        /// <inheritdoc/>
         public override void Flush() => this.BaseStream.Flush();
 
         /// <inheritdoc/>
@@ -270,6 +250,34 @@ namespace Elskom.Generic.Libs
 
         /// <inheritdoc/>
         public override void SetLength(long value) => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (!this.isDisposed)
+            {
+                if (disposing)
+                {
+                    try
+                    {
+                        try
+                        {
+                            this.Finish();
+                        }
+                        catch
+                        {
+                        }
+                    }
+                    finally
+                    {
+                        this.EndStream();
+                    }
+                }
+
+                this.isDisposed = true;
+                base.Dispose(disposing);
+            }
+        }
 
         private void InitBlock()
         {


### PR DESCRIPTION
According to the source code for stream. You should not override `Close` rather all cleanup logic should be called from `Dispose(bool)`.

>Stream used to require that all cleanup logic went into Close(),
which was thought up before we invented IDisposable.  However, we
need to follow the IDisposable pattern so that users can write
sensible subclasses without needing to inspect all their base
classes, and without worrying about version brittleness, from a
base class switching to the Dispose pattern.  We're moving
Stream to the Dispose(bool) pattern - that's where all subclasses
should put their cleanup now.

https://source.dot.net/#System.Private.CoreLib/Stream.cs,284