### PR TITLE
Decompression fix

### DIFF
--- a/zlib.managed/InfBlocks.cs
+++ b/zlib.managed/InfBlocks.cs
@@ -79,8 +79,6 @@ namespace Elskom.Generic.Libs
                 case 6:
                     InfCodes.Free();
                     break;
-                default:
-                    throw new InvalidOperationException();
             }
 
             this.mode = 0;

--- a/zlib.managed/Inflate.cs
+++ b/zlib.managed/Inflate.cs
@@ -47,8 +47,8 @@ namespace Elskom.Generic.Libs
 
                         z.AvailIn--;
                         z.TotalIn++;
-                        z.IState.Method = z.NextIn[z.NextInIndex++] & 0xf;
-                        if (z.IState.Method is not 8)
+                        z.IState.Method = z.NextIn[z.NextInIndex++];
+                        if ((z.IState.Method & 0xf) is not 8)
                         {
                             z.IState.Mode = 13;
                             z.Msg = "unknown compression method";

--- a/zlib.managed/ZlibStream.cs
+++ b/zlib.managed/ZlibStream.cs
@@ -166,7 +166,7 @@ namespace Elskom.Generic.Libs
                     var bytesRead = this.BaseStream.Read(this.pBuf, 0, this.BufSize);
                     if (bytesRead > 0)
                     {
-                        this.NextIn = pBuf;
+                        this.NextIn = this.pBuf;
                         this.AvailIn = bytesRead;
                         this.MoreInput = true;
                     }

--- a/zlib.managed/ZlibStream.cs
+++ b/zlib.managed/ZlibStream.cs
@@ -162,15 +162,12 @@ namespace Elskom.Generic.Libs
                 {
                     // if buffer is empty and more input is available, refill it
                     this.NextInIndex = 0;
-                    if (this.pBuf.Length == 0)
-                    {
-                        this.AvailIn = 0;
-                    }
 
                     var bytesRead = this.BaseStream.Read(this.pBuf, 0, this.BufSize);
-                    if (bytesRead == 0)
+                    if (bytesRead > 0)
                     {
-                        this.AvailIn = 0;
+                        this.NextIn = pBuf;
+                        this.AvailIn = bytesRead;
                         this.MoreInput = true;
                     }
                 }


### PR DESCRIPTION
# Checklist

- [x] I have read the Code of Conduct and the Contributing files before opening this issue.
- [X] I have verified the issue this pull request fixes or feature this pull request implements is to the current release.
- [X] I am using the latest stable release with the above code fix or the current main branch if code changes are present (prerelease code changes).
- [X] I have debugged and tested my changes before submitting this issue and that everything should just work.

## Describe the issue this fixes / feature this adds

There are multiple decompression bugs in the latest code. 
Reproduce the problem: call `MemoryZlib.Decompress(buf)` with any valid data.
This PR fixes them.

1st:
mode is 0 when the stream is created. So it alsways throws an exception on decomress....
Removed the default case, since it was not present in the original code. Why was it added?
https://github.com/philippelatulippe/ZLIB.NET/blob/57c8e9e4db0690cc8eecfbdef31ccf5ddc09f4a7/InfBlocks.cs#L114-L133

2nd:
Method field contains wrong value (masked with 0x0f). Original code contains the full byte.
https://github.com/philippelatulippe/ZLIB.NET/blob/57c8e9e4db0690cc8eecfbdef31ccf5ddc09f4a7/Inflate.cs#L176-L191

3rd:
Read logic is wrong. Probably never tested it, since NextIn and AvailIn was never assigned. Why do you check the length of the buffer? It is always BufSize.